### PR TITLE
[Github Actions]: Corrected Env Variable Names

### DIFF
--- a/.github/workflows/test.gmritw.hosting.org.yml
+++ b/.github/workflows/test.gmritw.hosting.org.yml
@@ -23,6 +23,6 @@ jobs:
             - name: 📂 Sync files
               uses: SamKirkland/FTP-Deploy-Action@4.3.1
               with:
-                  server: ${{ftp_server}}
-                  username: ${{ftp_username}}
-                  password: ${{ ftp_password }}
+                  server: ${{ secrets.ftp_server }}
+                  username: ${{ secrets.ftp_username }}
+                  password: ${{ secrets.ftp_password }}


### PR DESCRIPTION
previously forgot to add secrets while mentioning Github secret variables